### PR TITLE
Added food.nourishment

### DIFF
--- a/src/main/java/us/timinc/jsonifycraft/description/FoodDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/description/FoodDescription.java
@@ -5,13 +5,15 @@ import net.minecraft.item.Item;
 import us.timinc.jsonifycraft.JsonifyCraft;
 import us.timinc.jsonifycraft.description.tidbits.EffectDescription;
 import us.timinc.jsonifycraft.world.JsonedFood;
+import us.timinc.mcutil.MCRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class FoodDescription extends ItemDescription {
   public int hunger;
-  public float saturation;
+  public float saturation = -1.0F;
+  public String nourishment = "normal";
   public boolean meat;
   public boolean canEatWhenFull;
   public boolean fastToEat;
@@ -37,7 +39,7 @@ public class FoodDescription extends ItemDescription {
     if (food == null) {
       Food.Builder foodBuilder = new Food.Builder()
           .hunger(hunger)
-          .saturation(saturation);
+          .saturation(getSaturation());
       if (meat) {
         foodBuilder.meat();
       }
@@ -53,5 +55,13 @@ public class FoodDescription extends ItemDescription {
       food = foodBuilder.build();
     }
     return food;
+  }
+
+  public float getSaturation() {
+    if (saturation != -1.0F) {
+      return saturation;
+    } else {
+      return MCRegistry.NOURISHMENT_TIERS.getFromName(nourishment);
+    }
   }
 }

--- a/src/main/java/us/timinc/mcutil/MCRegistry.java
+++ b/src/main/java/us/timinc/mcutil/MCRegistry.java
@@ -280,6 +280,33 @@ public abstract class MCRegistry<T> {
         }
     }.setup();
 
+    public static MCRegistry<Float> NOURISHMENT_TIERS = new MCRegistry<Float>() {
+        private Map<String, Float> nourishment_tiers;
+
+        @Override
+        public MCRegistry<Float> setup() {
+            nourishment_tiers = new HashMap<>();
+
+            nourishment_tiers.put("SUPERNATURAL", 2.4F);
+            nourishment_tiers.put("GOOD", 1.6F);
+            nourishment_tiers.put("NORMAL", 1.2F);
+            nourishment_tiers.put("LOW", 0.6F);
+            nourishment_tiers.put("POOR", 0.2F);
+
+            return this;
+        }
+
+        @Override
+        public Float getFromName(String name) {
+            return nourishment_tiers.get(name.toUpperCase());
+        }
+
+        @Override
+        public boolean isValidName(String name) {
+            return nourishment_tiers.containsKey(name.toUpperCase());
+        }
+    }.setup();
+
     public abstract MCRegistry<? extends T> setup();
 
     public abstract T getFromName(String name);


### PR DESCRIPTION
This is an easy alternative to food.saturation. It uses a registry that indexes the values present at https://minecraft.gamepedia.com/Food#Nourishment_value.
As a result of adding this, food.saturation logic has changed. It defaults to -1.0F, which ignores the value and uses food.nourishment instead. Setting food.saturation manually overrides food.nourishment.